### PR TITLE
URL schema changed for Muji online store.

### DIFF
--- a/hardware/gel-ink-0.38mm.yml
+++ b/hardware/gel-ink-0.38mm.yml
@@ -1,4 +1,4 @@
 ---
 title: "Gel-Ink 0.38mm"
-url: "http://www.muji.us/store/stationery/pen-pencil/gel-ink-ball-point-pen-0-38mm.html"
+url: "http://www.muji.us/store/gel-ink-ballpoint-pen-0-38mm.html"
 description: "A ball-point pen."


### PR DESCRIPTION
New link for 0.38mm gel ink pen. Broken link found in [Adewale Oshineye](http://adewale.oshineye.usesthis.com/)'s interview.
