### PR TITLE
Update Pilot pen URLs.

### DIFF
--- a/data/wares/hardware/g2-pro.yml
+++ b/data/wares/hardware/g2-pro.yml
@@ -1,4 +1,4 @@
 ---
 name: G2 Pro
 description: A pen.
-url: http://pilotpen.us/ProductGroup/33-G2Pro.aspx
+url: http://pilotpen.us/categories/gel-ink-pens/g2-pro/

--- a/data/wares/hardware/g2.2.yml
+++ b/data/wares/hardware/g2.2.yml
@@ -1,4 +1,4 @@
 ---
 name: G2
 description: A pen.
-url: http://pilotpen.us/ProductGroup/35-G2.aspx?ProductId=362
+url: http://pilotpen.us/categories/gel-ink-pens/g2/

--- a/data/wares/hardware/precise-v5.yml
+++ b/data/wares/hardware/precise-v5.yml
@@ -1,4 +1,4 @@
 ---
 name: Precise V5
 description: A pen.
-url: http://pilotpen.us/ProductGroup/97-PreciseV5.aspx
+url: http://pilotpen.us/categories/rolling-ball-pens/precise-v5-v7/

--- a/data/wares/hardware/precise-v7.yml
+++ b/data/wares/hardware/precise-v7.yml
@@ -1,4 +1,4 @@
 ---
 name: Precise V7
 description: A pen.
-url: http://www.amazon.com/Pilot-Precise-Stick-Rolling-Point/dp/B00006IEBL/
+url: http://pilotpen.us/categories/rolling-ball-pens/precise-v5-v7/

--- a/data/wares/hardware/v-razor-point.yml
+++ b/data/wares/hardware/v-razor-point.yml
@@ -1,4 +1,4 @@
 ---
 name: V Razor Point
 description: A pen.
-url: http://pilotpen.us/ProductGroup/53-Vrazor-Point.aspx
+url: http://pilotpen.us/categories/stick-capped-pens/v-razor-point/


### PR DESCRIPTION
Pilot's website got rejigged, and all the Pilot Pen links 404; this updates all those URLs, and also switches `precise-v7` to point at the Pilot website, not Amazon.
