### PR TITLE
Fix the URL to Griffin Elevator stand

### DIFF
--- a/gear/hardware/elevator.yml
+++ b/gear/hardware/elevator.yml
@@ -1,4 +1,4 @@
 ---
 name: Elevator
 description: A laptop stand.
-url: http://store.griffintechnology.com/elevator
+url: https://griffintechnology.com/us/products/stands-and-mounts/elevator


### PR DESCRIPTION
The old URL returns 404, which means that Alice's [interview](https://usesthis.com/interviews/alice.goldfuss/) has a non-functioning URL, and that should simply not be done to a system administrator.

Hope you're having fun on the new continent! :) 