### PR TITLE
Fixes the piano image path in the Rich Vreeland interview

### DIFF
--- a/posts/2016-10-11-rich.vreeland.markdown
+++ b/posts/2016-10-11-rich.vreeland.markdown
@@ -17,7 +17,7 @@ My name is [Rich Vreeland](http://disasterpeace.com/ "Rich's website."), and I d
 
 I try to keep my hardware setup as minimal as possible. I have a [2012 MacBook Pro][macbook-pro] that I use for all of my work, and an iPad I occasionally mess with too. I've got a pair of [Sennheiser HD 600s][hd-600], Yamaha HS8 monitors + sub, and an old Novation Remote SL 61-Key MIDI Controller. I've also got a Yamaha Upright Piano that I love very much, and a few guitars. I wanna buy an electronic drum kit.
 
-<img src="/images/interviews/rich.vreeland.piano.jpg" width="500" height="500" alt="A photo of Rich's piano." class="detail">
+<img src="/images/interviews/rich.vreeland/piano.jpg" width="500" height="500" alt="A photo of Rich's piano." class="detail">
 
 I figured out that having a big desk was eating into my stereo field, so I switched it up for a very small, shallow desk, which is actually a piece of composite wood I found in my backyard, vice gripped together with Floyd Legs. I usually mount a big flat screen display to the wall in front of me, behind my monitors (speakers).
 


### PR DESCRIPTION
I noticed the piano.jpg image wasn't showing correctly on usesthis.com, so I figured out what the correct image path would be and fixed it here.

Thanks for the website, I've been happily reading for years!