### PR TITLE
fix: fit search bar in aside

### DIFF
--- a/static/stylesheets/screen.css
+++ b/static/stylesheets/screen.css
@@ -141,6 +141,7 @@ img.detail, img.portrait {
 }
 
 input[type=search] {
+  width: 100%;
   background-color: var(--divider-colour);
 }
 


### PR DESCRIPTION
`<input>` element was overflowing from aside. fixed by adding `width: 100%`.

| before | after |
|-|-|
| ![image](https://github.com/scarf005/usesthis/assets/54838975/4587cf35-afbe-4da0-845b-c7ba6f997264) | ![image](https://github.com/scarf005/usesthis/assets/54838975/8db952c8-e6f4-4552-bffd-edad5fb6b4ce)|